### PR TITLE
narrowing autoload namespace, adding codeclimate, adding vendor dir to includePath for test helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,14 @@ jobs:
         - composer phpstan
     - stage: test with coverage
       php: 7.1
-      env: TMPDIR=/tmp USE_XDEBUG=true
+      env: TMPDIR=/tmp USE_XDEBUG=true CC_TEST_REPORTER_ID=5d697626ab825004f7c24175198e56c0a49f55062a240eee92e6c6f2e2f3a1bf
+      before_script:
+        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - chmod +x ./cc-test-reporter
+        - ./cc-test-reporter before-build
       script:
         - composer test-with-coverage
       after_success:
         - bash <(curl -s https://codecov.io/bash) -f ./clover.xml
+      after_script:
+        - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,11 @@
     },
     "autoload": {
         "psr-0": {
-            "Zend_": "src/"
-        }
+            "Zend_Session_": "src/"
+        },
+        "classmap": [
+            "src/Zend/Session.php"
+        ]
     },
     "autoload-dev": {
         "psr-0": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,9 @@
     backupGlobals="true"
     stderr="true"
     colors="true">
+    <php>
+        <includePath>./vendor</includePath>
+    </php>
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>

--- a/tests/Zend/Session/SessionTestHelper.php
+++ b/tests/Zend/Session/SessionTestHelper.php
@@ -22,7 +22,7 @@
 
 // This helper file is executed in SessionTest via exec() calls, so this is necessary
 // to be able to autoload classes that are present in this file.
-require_once __DIR__ . '/../../../vendor/autoload.php';
+require_once 'autoload.php';
 
 /**
  * @category   Zend


### PR DESCRIPTION
The includePath change is so that these tests can run in the main diablomedia/zf1 repo.