### PR TITLE
Drop code based on session.hash_bits_per_character

### DIFF
--- a/src/Zend/Session.php
+++ b/src/Zend/Session.php
@@ -512,17 +512,7 @@ class Zend_Session extends Zend_Session_Abstract
             }
         }
 
-        $hashBitsPerChar = ini_get('session.hash_bits_per_character');
-        if (!$hashBitsPerChar) {
-            $hashBitsPerChar = 5; // the default value
-        }
-        $pattern = '';
-        switch ($hashBitsPerChar) {
-            case 4: $pattern = '^[0-9a-f]*$'; break;
-            case 5: $pattern = '^[0-9a-v]*$'; break;
-            case 6: $pattern = '^[0-9a-zA-Z-,]*$'; break;
-        }
-        return preg_match('#' . $pattern . '#', $id);
+        return preg_match('#^[0-9a-zA-Z-,]*$#', $id);
     }
 
 


### PR DESCRIPTION
This ini setting was removed in PHP 7.2, see https://www.php.net/manual/fr/session.configuration.php#ini.session.hash-bits-per-character 

We've successfully used this code in production on PHP 7.2 for 3 years now, in an application that uses both Zend Framework 1 and Symfony 5. We've had to apply a few changes to Zend's session code, and this one felt like you could benefit from it.

Here are the other ones, though I think they should not be applied without careful consideration : 

```diff
diff --git a/src/Zend/Session/Abstract.php b/src/Zend/Session/Abstract.php
index 57f8dc2..2e2ea6e 100644
--- a/src/Zend/Session/Abstract.php
+++ b/src/Zend/Session/Abstract.php
@@ -37,14 +37,14 @@ abstract class Zend_Session_Abstract
      *
      * @var bool
      */
-    protected static $_writable = false;
+    protected static $_writable = true;
 
     /**
      * Whether or not session permits reading (reading data in $_SESSION[])
      *
      * @var bool
      */
-    protected static $_readable = false;
+    protected static $_readable = true;
 
     /**
      * Since expiring data is handled at startup to avoid __destruct difficulties,
@@ -100,6 +100,10 @@ abstract class Zend_Session_Abstract
      */
     protected static function _namespaceUnset($namespace, $name = null)
     {
+        if (!isset($_SESSION)) {
+            return;
+        }
+
         if (self::$_writable === false) {
             throw new Zend_Session_Exception(self::_THROW_NOT_WRITABLE_MSG);
         }
diff --git a/src/Zend/Session/Namespace.php b/src/Zend/Session/Namespace.php
index 8865fcd..8696250 100644
--- a/src/Zend/Session/Namespace.php
+++ b/src/Zend/Session/Namespace.php
@@ -111,9 +111,6 @@ class Zend_Session_Namespace extends Zend_Session_Abstract implements IteratorAg
 
         $this->_namespace = $namespace;
 
-        // Process metadata specific only to this namespace.
-        Zend_Session::start(true); // attempt auto-start (throws exception if strict option set)
-
         if (self::$_readable === false) {
             throw new Zend_Session_Exception(self::_THROW_NOT_READABLE_MSG);
         }

```